### PR TITLE
Fixed error interpreting the model with CPU

### DIFF
--- a/interpret_model.py
+++ b/interpret_model.py
@@ -723,10 +723,11 @@ if __name__ == '__main__':
 
     data = load_data(config=config, word_to_idx=w2i)
 
-    model = torch.load(model_path+'/model')
-
     if config["cuda"]:
+        model = torch.load(model_path+'/model')
         model = model.cuda()
+    else:
+        model = torch.load(model_path+'/model', map_location=torch.device('cpu'))
 
     for ngram_size in config["ngram_sizes"]:
         for filter_ix in range(config["num_filters"]):


### PR DESCRIPTION
Hello from MIT. I understand that most of the time people want to run the model interpretation in GPU mode. However, when they use the CPU mode, they will get the following error:

RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

This error is fixed by the code here without affecting the GPU execution. 